### PR TITLE
Use name-vsn for lib dir

### DIFF
--- a/src/emqx_plugrel.erl
+++ b/src/emqx_plugrel.erl
@@ -2,6 +2,8 @@
 
 -export([init/1, do/1, format_error/1]).
 
+-define(METADATA_VSN, <<"0.1.0">>).
+
 -define(LOG(LEVEL, FORMAT, ARGS),
         rebar_api:LEVEL("[emqx_plugrel] " ++ FORMAT, ARGS)).
 
@@ -45,6 +47,7 @@ collect_info(PluginInfo, Name, Version, Apps, State) ->
                 , rel_vsn => bin(Version)
                 , rel_apps => AppsWithVsn
                 , git_ref => git_ref()
+                , metadata_vsn => ?METADATA_VSN
                 },
     maps:merge(Info, MoreInfo).
 

--- a/src/emqx_plugrel.erl
+++ b/src/emqx_plugrel.erl
@@ -81,14 +81,14 @@ make_tar(#{name := Name, rel_vsn := Vsn, rel_apps := Apps} = Info, State) ->
     BaseDir = rebar_dir:base_dir(State),
     Dir = filename:join([BaseDir, ?MODULE]),
     NameWithVsn = binary_to_list(bin([Name, "-", Vsn])),
-    %% write info file
-    InfoFile = filename:join([Dir, NameWithVsn ++ ".json"]),
+    LibDir = filename:join([Dir, NameWithVsn]),
+    InfoFile = filename:join([LibDir, "release" ++ ".json"]),
+    %% ensure clean state
+    ok = rebar_file_utils:rm_rf(LibDir),
     ok = filelib:ensure_dir(InfoFile),
+    %% write info file
     ok = file:write_file(InfoFile, jsx:encode(Info, [space, {indent, 4}])),
     %% copy apps to lib dir
-    LibDir = filename:join([Dir, lib]),
-    ok = rebar_file_utils:rm_rf(LibDir),
-    ok = filelib:ensure_dir(filename:join([LibDir, "foo"])),
     Sources = lists:map(fun(App) -> filename:join([BaseDir, "rel", Name, "lib", App]) end, Apps),
     ok = rebar_file_utils:cp_r(Sources, LibDir),
     {ok, OriginalCwd} = file:get_cwd(),
@@ -97,16 +97,14 @@ make_tar(#{name := Name, rel_vsn := Vsn, rel_apps := Apps} = Info, State) ->
         do_make_tar(Dir, NameWithVsn)
     after
         file:set_cwd(OriginalCwd)
-    end,
-    ok = file:delete(InfoFile),
-    ok = rebar_file_utils:rm_rf(LibDir).
+    end.
 
 do_make_tar(Cwd, NameWithVsn) ->
-    Files = filelib:wildcard("lib/**"),
+    Files = filelib:wildcard(NameWithVsn ++ "/**"),
     TarFile = NameWithVsn ++ ".tar.gz",
     FullName = filename:join([Cwd, TarFile]),
     ?LOG(info, "creating ~ts", [FullName]),
-    ok = erl_tar:create(TarFile, [NameWithVsn ++ ".json"| Files], [compressed]),
+    ok = erl_tar:create(TarFile, Files, [compressed]),
     {ok, Bin} = file:read_file(TarFile),
     Sha = bin2hexstr(crypto:hash(sha256, Bin)),
     ok = file:write_file(NameWithVsn ++ ".sha256", Sha).


### PR DESCRIPTION
This PR renames the `lib` dir to `<rel_name>-<rel_vsn>` to make it easier to manage plugin installations.
The descriptive JSON file has been moved to inside the release dir, named `release.json`

Using a shared lib dir for different plugins may complicate
installation management.
e.g. when un-installing a plugin, we can't be sure if the beams
are actually used by other plugins.

example release dir:
```
.
├── emqx_plugin_template-5.0.0
│   ├── ebin
│   │   ├── emqx_cli_demo.beam
│   │   ├── emqx_plugin_template.app
│   │   ├── emqx_plugin_template.beam
│   │   ├── emqx_plugin_template_app.beam
│   │   └── emqx_plugin_template_sup.beam
│   ├── priv
│   │   └── config.hocon
│   └── src
│       ├── emqx_cli_demo.erl
│       ├── emqx_plugin_template.app.src
│       ├── emqx_plugin_template.erl
│       ├── emqx_plugin_template_app.erl
│       └── emqx_plugin_template_sup.erl
├── map_sets-1.1.0
│   ├── ebin
│   │   ├── map_sets.app
│   │   └── map_sets.beam
│   └── src
│       ├── map_sets.app.src
│       └── map_sets.erl
└── release.json

```
example release.json
```
{
    "authors": [
        "EMQ X Team"
    ],
    "builder": {
        "contact": "emqx-support@emqx.io",
        "name": "EMQ X Team",
        "website": "www.emqx.com"
    },
    "compatibility": {
        "emqx": "~> 5.0"
    },
    "description": "This is a demo plugin",
    "functionality": [
        "Demo"
    ],
    "git_ref": "7de896f158838290cd885686cd80dd7f9c1bf9aa",
    "metadata_vsn": "0.1.0",
    "name": "emqx_plugin_template",
    "rel_apps": [
        "emqx_plugin_template-5.0.0",
        "map_sets-1.1.0"
    ],
    "rel_vsn": "5.0.0",
    "repo": "https://github.com/emqx/emqx-plugin-template"
}
```