### PR TITLE
fix: the generated tar package does not include the lib files

### DIFF
--- a/src/emqx_plugrel.erl
+++ b/src/emqx_plugrel.erl
@@ -31,7 +31,7 @@ do(State) ->
         [Rel] ->
             Name = rlx_release:name(Rel),
             Version = rlx_release:vsn(Rel),
-            Apps = [App || {App, _} <- rlx_release:app_specs(Rel)],
+            Apps = [App || {App, _} <- rlx_release:goals(Rel)],
             PluginInfo = rebar_opts:get(Opts, emqx_plugrel),
             Info = collect_info(PluginInfo, Name, Version, Apps, State),
             ok = make_tar(Info, State);
@@ -80,7 +80,7 @@ cmd_oneline_output(Cmd) ->
         {ok, Line} ->
             bin(rebar_string:trim(Line, trailing, "\n"));
         {error, {Rc, Output}} ->
-            ?LOG(debug, "failed_run_cmd ~s~n, error=~p~noutput:~n~ts~n", [Rc, Output]),
+            ?LOG(debug, "failed_run_cmd ~s~n, error=~p~noutput:~n~ts~n", [Cmd, Rc, Output]),
             error
     end.
 


### PR DESCRIPTION
report from : https://askemq.com/t/topic/7297
before:
```
tar -xvf my_emqx_plugin-1.0.0.tar.gz
x my_emqx_plugin-1.0.0/README.md
x my_emqx_plugin-1.0.0/release.json
```
after:
```
tar -xvf my_emqx_plugin-1.0.0.tar.gz
x my_emqx_plugin-1.0.0/README.md
x my_emqx_plugin-1.0.0/map_sets-1.1.0/ebin/map_sets.beam
x my_emqx_plugin-1.0.0/map_sets-1.1.0/ebin/map_sets.app
x my_emqx_plugin-1.0.0/map_sets-1.1.0/src/map_sets.app.src
x my_emqx_plugin-1.0.0/map_sets-1.1.0/src/map_sets.erl
x my_emqx_plugin-1.0.0/map_sets-1.1.0/ebin/map_sets.beam
x my_emqx_plugin-1.0.0/map_sets-1.1.0/ebin/map_sets.app
x my_emqx_plugin-1.0.0/map_sets-1.1.0/ebin/map_sets.app
x my_emqx_plugin-1.0.0/map_sets-1.1.0/ebin/map_sets.beam
x my_emqx_plugin-1.0.0/map_sets-1.1.0/src/map_sets.app.src
x my_emqx_plugin-1.0.0/map_sets-1.1.0/src/map_sets.erl
x my_emqx_plugin-1.0.0/map_sets-1.1.0/src/map_sets.app.src
x my_emqx_plugin-1.0.0/map_sets-1.1.0/src/map_sets.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin_app.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin_sup.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin_cli.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin.app
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/priv/config.hocon
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin.app.src
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin_cli.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin_sup.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin_app.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin_app.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin_sup.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin_cli.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin.app
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin.app
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin_app.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin_cli.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/ebin/my_emqx_plugin_sup.beam
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/priv/config.hocon
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/priv/config.hocon
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin.app.src
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin_cli.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin_sup.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin_app.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin.app.src
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin_app.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin_cli.erl
x my_emqx_plugin-1.0.0/my_emqx_plugin-0.1.0/src/my_emqx_plugin_sup.erl
x my_emqx_plugin-1.0.0/release.json
```
