### PR TITLE
chore: bump hocon to `0.43.3`

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,6 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.42.2"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.43.3"}}},
     {erlavro, {git, "https://github.com/emqx/erlavro.git", {tag, "2.10.0"}}}
 ]}.


### PR DESCRIPTION
- Keep consistent with the version that the EMQX depends on