### PR TITLE
chore: pin hocon 0.45.9

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,6 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.44.0"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.45.9"}}},
     {erlavro, {git, "https://github.com/emqx/erlavro.git", {tag, "2.10.2-emqx-3"}}}
 ]}.


### PR DESCRIPTION
so the transitive dependency erlnag_qq is pined with a tag instead of a branch